### PR TITLE
大佬，发现您的项目引入了mysql:mysql-connector-java@5.1.46组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.example</groupId>
@@ -46,7 +45,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.46</version>
+            <version>8.0.28</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Oracle MySQL Connectors访问控制错误漏洞
缺陷组件：mysql:mysql-connector-java@5.1.46
漏洞编号：CVE-2018-3258
漏洞描述：Oracle MySQL是美国甲骨文（Oracle）公司的一套开源的关系数据库管理系统。该数据库系统具有性能高、成本低、可靠性好等特点。MySQL Connectors是其中的一个连接使用MySQL的应用程序的驱动程序。
Oracle MySQL Connectors存在访问控制错误漏洞。攻击者可利用该漏洞控制组件，影响数据的保密性、完整性和可用性。
国家漏洞库信息：https://www.cnvd.org.cn/flaw/show/CNVD-2019-39877
影响范围：(∞, 8.0.13)
最小修复版本：8.0.28
缺陷组件引入路径：com.example:competition-demo@0.0.1-SNAPSHOT->mysql:mysql-connector-java@5.1.46
```
另外我运行这个项目时，IDE的安全插件提示还有87个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=pcfa12